### PR TITLE
Fix CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -114,19 +114,6 @@ services:
 
 matrix:
   include:
-    # 5.6
-    #- STORAGE: ceph
-    #  PHP_VERSION: 5.6
-    #  OC_VERSION: daily-stable10-qa
-
-    - STORAGE: scality
-      PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
-
-    #- STORAGE: minio
-    #  PHP_VERSION: 5.6
-    #  OC_VERSION: daily-stable10-qa
-
     # 7.0
     #- STORAGE: ceph
     #  PHP_VERSION: 7.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ Administrators and users (when enabled) can find external storage configuration 
     </types>
 
     <dependencies>
-        <owncloud min-version="10.0" max-version="10.0"/>
+        <owncloud min-version="10.2" max-version="10"/>
     </dependencies>
     <website>https://github.com/owncloud/files_external_s3/</website>
     <bugs>https://github.com/owncloud/files_external_s3/issues</bugs>


### PR DESCRIPTION
- core stable10 no longer supports PHP 5.6 owncloud/core#34698
- core stable10 is now 10.2