### PR TITLE
Fix typo to check for operations GetBucketAcl

### DIFF
--- a/lib/Storage/AmazonS3.php
+++ b/lib/Storage/AmazonS3.php
@@ -531,7 +531,7 @@ class AmazonS3 extends \OCP\Files\Storage\StorageAdapter {
 	}
 
 	public function test() {
-		if ($this->getConnection()->getApi()->hasOperation('getBucketAcl')) {
+		if ($this->getConnection()->getApi()->hasOperation('GetBucketAcl')) {
 
 			$test = $this->getConnection()->getBucketAcl([
 				'Bucket' => $this->bucket,


### PR DESCRIPTION
Fix typo to check if the api has operations
GetBucketAcl. Earlier it was checked for
getBucketAcl, due to which there was a noticable
failure.

Signed-off-by: Sujith H <sharidasan@owncloud.com>