### PR TITLE
Fix composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "files_external_s3",
+    "name": "owncloud/files_external_s3",
     "description": "files external adapter for S3",
     "license": "GPLv2",
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c6a63b870f0a435df96731dde84a14f",
+    "content-hash": "10e007a9846e5ec6a92f8c07fadcee5a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",


### PR DESCRIPTION
When updating dependencies there is a deprecation warning:
```
composer update
Deprecation warning: Your package name files_external_s3 is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating aws/aws-sdk-php (3.110.3 => 3.112.34): Loading from cache
Writing lock file
Generating optimized autoload files
```

Fix the package name.