### PR TITLE
feat: performance optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "aws/aws-sdk-php": "^3.93"
     },
     "require-dev": {
+        "roave/security-advisories": "dev-latest",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "extra": {


### PR DESCRIPTION
- use CurlMultiHandler
- don't use part files

Using part files in S3 context is highly sub-optimal.

Uploading with part files in S3 means:
- upload part file
- copy part file to final
- delete part file

As soon as s3 versioning is enabled this will result in a total mess - deleted files will not be really deleted but marked as deleted.
So worst case uploading one file results in:
- part file with 1 version and delete marker
- the real files with 2 versions - due to the rename/copy (seen with backblaze)

