### PR TITLE
chore(ci): run PHP unit tests with scality S3 seerver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,12 @@ jobs:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
 
+  php-unit:
+    name: PHP Unit
+    needs:
+      - get-vars
+    uses: ./.github/workflows/php-unit.yml
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      php-versions: ${{ needs.get-vars.outputs.php-versions }}
+      use-scality-s3: true

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -44,6 +44,16 @@ on:
         required: false
         type: string
         default: ''
+      use-scality-s3:
+        description: 'Provide a scality S3 server for tests to use'
+        required: false
+        type: boolean
+        default: false
+      use-ceph-s3:
+        description: 'Provide a ceph S3 server for tests to use'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -139,6 +149,25 @@ jobs:
         env:
           fail-fast: true
           KRB5_LINUX_LIBS: libkrb5-dev
+
+      - name: Scality S3 Server
+        if: ${{ inputs.use-scality-s3 }}
+        env:
+          HOST_NAME: localhost
+          SCALITY_ACCESS_KEY_ID: owncloud123456
+          SCALITY_SECRET_ACCESS_KEY: secret123456
+        run: |
+          docker run -d --rm --network host \
+            --name scality \
+            owncloudci/scality-s3server
+
+      - name: Setup for Scality S3 Server tests
+        if: ${{ inputs.use-scality-s3 }}
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+        run: |
+          cd "apps/${APP_NAME}"
+          cp tests/drone/configs/config.scality.php tests/unit/config.php
 
       - name: Install Core Dependencies
         run: |

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -1,0 +1,218 @@
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: 'Name of the app'
+        required: true
+        type: string
+      php-versions:
+        description: JSON array of PHP versions
+        required: true
+        type: string
+      core-ref:
+        description: 'git reference to checkout for core'
+        required: false
+        type: string
+        default: ''
+      core-ref-php74:
+        description: 'git reference to checkout for core if PHP 7.4 is used'
+        required: false
+        type: string
+        default: ''
+      app-repository:
+        description: 'Repository of the app (optional, defaults to the current repository)'
+        required: false
+        type: string
+        default: ''
+      do-integration-tests:
+        description: 'Whether to run PHP integration tests'
+        required: false
+        type: boolean
+        default: false
+      additional-app:
+        description: 'Additional app to enable for testing'
+        required: false
+        type: string
+        default: ''
+      additional-app-github-token:
+        description: 'GitHub PAT to access the additional app repo - required if private'
+        required: false
+        type: string
+        default: ''
+      additional-packages:
+        description: Additional Linux packages to be installed - space separated
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  php-unit:
+    name: PHP Unit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ${{ fromJSON(inputs.php-versions) }}
+        database: [sqlite]
+        include:
+          - php: ${{ fromJSON(inputs.php-versions)[0] }}
+            database: "mysql:8.0"
+          - php: ${{ fromJSON(inputs.php-versions)[0] }}
+            database: "mariadb:10.6"
+          - php: ${{ fromJSON(inputs.php-versions)[0] }}
+            database: "postgres:10.21"
+
+    services:
+      mysql:
+        image: >-
+          ${{ (startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:')) && matrix.database || '' }}
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: owncloud
+          MYSQL_USER: owncloud
+          MYSQL_PASSWORD: owncloud
+        options: >-
+          --health-cmd="mysqladmin ping -u root -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+        ports:
+          - 3306:3306
+      postgres:
+        image: ${{ startsWith(matrix.database,'postgres:') && matrix.database || '' }}
+        env:
+          POSTGRES_DB: owncloud
+          POSTGRES_USER: owncloud
+          POSTGRES_PASSWORD: owncloud
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Validate app-repository
+        if: ${{ inputs.app-repository != '' }}
+        env:
+          APP_REPO: ${{ inputs.app-repository }}
+        run: |
+          if ! echo "$APP_REPO" | grep -qE '^owncloud/[a-zA-Z0-9._-]+$'; then
+            echo "Error: app-repository must be within the owncloud/ namespace, got: $APP_REPO"
+            exit 1
+          fi
+
+      - name: Clone owncloud/core
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: owncloud/core
+          ref: ${{ case(matrix.php == '7.4', inputs.core-ref-php74, inputs.core-ref) }}
+
+      - name: Checkout apps/${{ inputs.app-name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: apps/${{ inputs.app-name }}
+          repository: ${{ inputs.app-repository }}
+
+      - name: Checkout apps/${{ inputs.additional-app }}
+        if: ${{ inputs.additional-app != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: apps/${{ inputs.additional-app }}
+          repository: owncloud/${{ inputs.additional-app }}
+          token: ${{ inputs.additional-app-github-token || github.token }}
+
+      - name: Install Linux packages
+        if: ${{ inputs.additional-packages }}
+        env:
+          ADDITIONAL_PACKAGES: ${{ inputs.additional-packages }}
+        run: |
+          sudo apt-get install $ADDITIONAL_PACKAGES
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: apcu, ctype, curl, exif, fileinfo, gd, iconv, imagick, intl, json, mbstring, memcached, pdo, posix, simplexml, xml, zip, smbclient, ldap, krb5
+          ini-values: "memory_limit=1024M"
+        env:
+          fail-fast: true
+          KRB5_LINUX_LIBS: libkrb5-dev
+
+      - name: Install Core Dependencies
+        run: |
+          make
+
+      - name: Install Server
+        env:
+          DATA_DIRECTORY: ${{ github.workspace }}/data
+          DB: ${{ matrix.database }}
+          DB_NAME: owncloud
+          ADMIN_LOGIN: admin
+          ADMIN_PASSWORD: admin
+          DB_HOST: 127.0.0.1
+          DB_USERNAME: owncloud
+          DB_PASSWORD: owncloud
+
+        run: |
+          DB_TYPE=${DB%:*}
+          if [ $DB_TYPE == "postgres" ] ; then DB_TYPE="pgsql"; fi
+          if [ $DB_TYPE == "mariadb" ] ; then DB_TYPE="mysql"; fi
+          install_cmd="maintenance:install -vvv \
+            --database=${DB_TYPE} \
+            --database-name=${DB_NAME} \
+            --admin-user=${ADMIN_LOGIN} \
+            --admin-pass=${ADMIN_PASSWORD} \
+            --data-dir=${DATA_DIRECTORY} "
+          
+          if [[ "${DB_TYPE}" != "sqlite" ]]; then
+            install_cmd+=" --database-host=${DB_HOST} \
+              --database-user=${DB_USERNAME} \
+              --database-pass=${DB_PASSWORD}"
+          fi
+          
+          php occ ${install_cmd}
+          echo "enabling apps"
+          php occ app:enable files_sharing
+          php occ app:enable files_trashbin
+          php occ app:enable files_versions
+          php occ app:enable provisioning_api
+          php occ app:enable federation
+          php occ app:enable federatedfilesharing
+
+      - name: Setup additional app
+        if: ${{ inputs.additional-app != '' }}
+        env:
+          ADDITIONAL_APP: ${{ inputs.additional-app }}
+        run: |
+          ( cd "apps/${ADDITIONAL_APP}" && make vendor || true)
+          php occ a:e "${ADDITIONAL_APP}"
+
+      - name: Setup app
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+        run: |
+          ( cd "apps/${APP_NAME}" && make vendor || true)
+          php occ a:e "${APP_NAME}"
+
+      - name: Run PHPUnit
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+        run: |
+          cd "apps/${APP_NAME}"
+          make test-php-unit
+
+      - name: Run PHP Integration tests
+        if: ${{ inputs.do-integration-tests }}
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+        run: |
+          cd "apps/${APP_NAME}"
+          make test-php-integration
+
+      - name: Tail log
+        if: always()
+        run: |
+          ls -la data
+          cat data/owncloud.log

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: owncloud/core
-          ref: ${{ case(matrix.php == '7.4', inputs.core-ref-php74, inputs.core-ref) }}
+          ref: ${{ (matrix.php == '7.4' && inputs.core-ref-php74) || inputs.core-ref }}
 
       - name: Checkout apps/${{ inputs.app-name }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -159,6 +159,9 @@ jobs:
         run: |
           docker run -d --rm --network host \
             --name scality \
+            -e HOST_NAME \
+            -e SCALITY_ACCESS_KEY_ID \
+            -e SCALITY_SECRET_ACCESS_KEY \
             owncloudci/scality-s3server
 
       - name: Setup for Scality S3 Server tests

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: apcu, ctype, curl, exif, fileinfo, gd, iconv, imagick, intl, json, mbstring, memcached, pdo, posix, simplexml, xml, zip, smbclient, ldap, krb5
-          ini-values: "memory_limit=1024M"
+          ini-values: "memory_limit=4096M"
         env:
           fail-fast: true
           KRB5_LINUX_LIBS: libkrb5-dev

--- a/tests/drone/configs/config.scality.php
+++ b/tests/drone/configs/config.scality.php
@@ -3,7 +3,7 @@
 return [
 	'run'           => true,
 	'bucket'        => 'owncloud',
-	'hostname'      => 'scality',
+	'hostname'      => 'localhost',
 	'port'          => '8000',
 	'key'           => 'owncloud123456',
 	'secret'        => 'secret123456',


### PR DESCRIPTION
## Summary

Adds GitHub Actions PHP unit testing for `files_external_s3`, exercising the S3
storage backend against a real **Scality S3** server — replacing the Drone-based
setup for these tests.

- **New reusable workflow `.github/workflows/php-unit.yml`** (`workflow_call`):
  checks out `owncloud/core` plus the app, sets up PHP with the standard
  extension set, optionally spins up an S3 server, installs the server across a
  database matrix, enables the app, and runs `make test-php-unit`.
  - **DB matrix:** each PHP version on `sqlite`, plus the first PHP version on
    `mysql:8.0`, `mariadb:10.6`, and `postgres:10.21` (as service containers).
  - **S3 backends via toggles:** `use-scality-s3` starts
    `owncloudci/scality-s3server` (used here) and copies
    `tests/drone/configs/config.scality.php` into `tests/unit/config.php`;
    `use-ceph-s3` is wired for future use.
  - Also supports optional `core-ref`/`core-ref-php74`, a private
    `app-repository`, an `additional-app` (with PAT), extra Linux packages, and
    `do-integration-tests`. Third-party actions are pinned to commit SHAs.

- **`main.yml`:** adds a `php-unit` job that calls the reusable workflow with
  `use-scality-s3: true`, wired to the existing `get-vars` outputs.

- **`config.scality.php`:** S3 `hostname` `scality` → `localhost`. The Scality
  container runs with `--network host`, so it is reachable on `localhost:8000`
  (Drone linked it by the container name `scality`).

## Test plan

- CI runs the new `PHP Unit` job on this PR; PHPUnit executes against the
  Scality S3 server across the sqlite/mysql/mariadb/postgres matrix.
- On failure, `data/owncloud.log` is tailed for diagnostics.
