### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,71 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: guzzlehttp/guzzle
-    versions:
-    - "< 7, >= 6.0.a"
-  - dependency-name: aws/aws-sdk-php
-    versions:
-    - 3.172.3
-    - 3.172.4
-    - 3.173.0
-    - 3.173.10
-    - 3.173.11
-    - 3.173.12
-    - 3.173.13
-    - 3.173.14
-    - 3.173.15
-    - 3.173.16
-    - 3.173.17
-    - 3.173.18
-    - 3.173.2
-    - 3.173.20
-    - 3.173.21
-    - 3.173.22
-    - 3.173.23
-    - 3.173.24
-    - 3.173.25
-    - 3.173.26
-    - 3.173.27
-    - 3.173.28
-    - 3.173.3
-    - 3.173.4
-    - 3.173.5
-    - 3.173.6
-    - 3.173.7
-    - 3.173.8
-    - 3.173.9
-    - 3.174.0
-    - 3.174.2
-    - 3.174.3
-    - 3.175.0
-    - 3.175.1
-    - 3.175.2
-    - 3.175.3
-    - 3.176.0
-    - 3.176.2
-    - 3.176.3
-    - 3.176.4
-    - 3.176.5
-    - 3.176.6
-    - 3.176.7
-    - 3.176.8
-    - 3.176.9
-    - 3.177.0
-    - 3.178.0
-    - 3.178.1
-    - 3.178.10
-    - 3.178.11
-    - 3.178.2
-    - 3.178.3
-    - 3.178.4
-    - 3.178.5
-    - 3.178.6
-    - 3.178.7
-    - 3.178.9
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
